### PR TITLE
undef TASK in general.cpp for safety reason

### DIFF
--- a/general.cpp
+++ b/general.cpp
@@ -17,6 +17,7 @@ void FileIO() {
         freopen(TASK".inp", "r", stdin);
         freopen(TASK".out", "w", stdout);
     }
+    #undef TASK
 }
 
 int main() {


### PR DESCRIPTION
Add `#undef TASK` in `general.cpp` for safety reason